### PR TITLE
Fix: generate a default-header in case the database-request has empty result

### DIFF
--- a/src/sql_table.cpp
+++ b/src/sql_table.cpp
@@ -145,6 +145,14 @@ SqlTable::getAllFromDb(TableItem &resultTable,
         return false;
     }
 
+    // if header is missing in result, because there are no entries to list, add a default-header
+    if(resultTable.getNumberOfColums() == 0)
+    {
+        for(const DbHeaderEntry &entry : m_tableHeader) {
+            resultTable.addColumn(entry.name);
+        }
+    }
+
     // remove all values, which should be hide
     if(showHiddenValues == false)
     {
@@ -180,6 +188,14 @@ SqlTable::getFromDb(TableItem &resultTable,
     {
         LOG_ERROR(error);
         return false;
+    }
+
+    // if header is missing in result, because there are no entries to list, add a default-header
+    if(resultTable.getNumberOfColums() == 0)
+    {
+        for(const DbHeaderEntry &entry : m_tableHeader) {
+            resultTable.addColumn(entry.name);
+        }
     }
 
     // remove all values, which should be hide

--- a/tests/functional_tests/sql_table_test.cpp
+++ b/tests/functional_tests/sql_table_test.cpp
@@ -68,16 +68,15 @@ SqlTable_Test::create_test()
     ErrorContainer error;
 
     Kitsunemimi::Json::JsonItem testData;
-    testData.insert("name", "user0815");
+    testData.insert("name", m_name1);
     testData.insert("pw_hash", "secret");
     testData.insert("is_admin", true);
 
-    m_uuid = "user0815";
     TEST_EQUAL(m_table->addUser(testData, error), true);
 
 
     Kitsunemimi::Json::JsonItem testData2;
-    testData2.insert("name", "another user");
+    testData2.insert("name", m_name2);
     testData2.insert("pw_hash", "secret2");
     testData2.insert("is_admin", false);
 
@@ -94,10 +93,10 @@ SqlTable_Test::get_test()
     TableItem resultTable;
     ErrorContainer error;
 
-    TEST_EQUAL(m_table->getUser(resultItem, m_uuid, error), true);
+    TEST_EQUAL(m_table->getUser(resultItem, m_name1, error), true);
     TEST_EQUAL(resultItem.toString(), std::string("{\"is_admin\":true,\"name\":\"user0815\"}"));
 
-    TEST_EQUAL(m_table->getUser(resultTable, m_uuid, error), true);
+    TEST_EQUAL(m_table->getUser(resultTable, m_name1, error), true);
     std::string compare = "+----------+----------+\n"
                           "| name     | is_admin |\n"
                           "+==========+==========+\n"
@@ -136,12 +135,12 @@ SqlTable_Test::update_test()
     Kitsunemimi::Json::JsonItem updateDate;
     updateDate.insert("pw_hash", "secret2");
     updateDate.insert("is_admin", false);
-    TEST_EQUAL(m_table->updateUser("user0815", updateDate, error), true);
+    TEST_EQUAL(m_table->updateUser(m_name1, updateDate, error), true);
 
     Kitsunemimi::Json::JsonItem resultItem;
     TableItem resultTable;
 
-    TEST_EQUAL(m_table->getUser(resultItem, m_uuid, error, true), true);
+    TEST_EQUAL(m_table->getUser(resultItem, m_name1, error, true), true);
     TEST_EQUAL(resultItem.toString(),
                std::string("{\"is_admin\":false,\"name\":\"user0815\",\"pw_hash\":\"secret2\"}"));
 }
@@ -152,12 +151,24 @@ SqlTable_Test::update_test()
 void
 SqlTable_Test::delete_test()
 {
-    TableItem result;
     ErrorContainer error;
 
-    TEST_EQUAL(m_table->deleteUser(m_uuid, error), true);
-    m_table->getAllUser(result, error);
-    TEST_EQUAL(result.getNumberOfRows(), 1);
+    TEST_EQUAL(m_table->deleteUser(m_name1, error), true);
+    TableItem result1;
+    m_table->getAllUser(result1, error);
+    TEST_EQUAL(result1.getNumberOfRows(), 1);
+    TEST_EQUAL(result1.getNumberOfColums(), 2);
+
+    TEST_EQUAL(m_table->deleteUser(m_name2, error), true);
+    TableItem result2;
+    m_table->getAllUser(result2, error);
+    TEST_EQUAL(result2.getNumberOfRows(), 0);
+    TEST_EQUAL(result2.getNumberOfColums(), 2);
+
+    TableItem result3;
+    m_table->getUser(result3, m_name1, error, true);
+    TEST_EQUAL(result2.getNumberOfRows(), 0);
+    TEST_EQUAL(result2.getNumberOfColums(), 2);
 }
 
 /**

--- a/tests/functional_tests/sql_table_test.h
+++ b/tests/functional_tests/sql_table_test.h
@@ -20,7 +20,8 @@ private:
     std::string m_filePath = "";
     TestTable* m_table = nullptr;
     SqlDatabase* m_db = nullptr;
-    std::string m_uuid = "";
+    std::string m_name1 = "user0815";
+    std::string m_name2 = "other";
 
     void deleteFile();
     void initTest();


### PR DESCRIPTION
## Description

Fix: generate a default-header in case the database-request has empty result

## Related Issues

- #14 

## How it was tested?

- updates functional tests in ci-pipeline
